### PR TITLE
Refactor in delete post logic

### DIFF
--- a/src/Controllers/ChatterPostController.php
+++ b/src/Controllers/ChatterPostController.php
@@ -8,6 +8,7 @@ use DevDojo\Chatter\Events\ChatterAfterNewResponse;
 use DevDojo\Chatter\Events\ChatterBeforeNewResponse;
 use DevDojo\Chatter\Mail\ChatterDiscussionUpdated;
 use DevDojo\Chatter\Models\Models;
+use DevDojo\Chatter\Requests\ChatterDeletePostRequest;
 use Event;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as Controller;
@@ -206,17 +207,10 @@ class ChatterPostController extends Controller
      *
      * @return \Illuminate\Routing\Redirect
      */
-    public function destroy($id, Request $request)
+    public function destroy($id, ChatterDeletePostRequest $request)
     {
         $post = Models::post()->with('discussion')->findOrFail($id);
-
-        if ($request->user()->id !== (int) $post->user_id) {
-            return redirect('/'.config('chatter.routes.home'))->with([
-                'chatter_alert_type' => 'danger',
-                'chatter_alert'      => trans('chatter::alert.danger.reason.destroy_post'),
-            ]);
-        }
-
+        
         if ($post->discussion->posts()->oldest()->first()->id === $post->id) {
             if(config('chatter.soft_deletes')) {
                 $post->discussion->posts()->delete();

--- a/src/Exceptions/ChatterUserIsNotAllowedToDeletePostException.php
+++ b/src/Exceptions/ChatterUserIsNotAllowedToDeletePostException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DevDojo\Chatter\Exceptions;
+
+use Exception;
+
+class ChatterUserIsNotAllowedToDeletePostException extends Exception
+{
+    
+    /**
+     * Report the exception.
+     *
+     * @return void
+     */
+    public function report()
+    {
+        //
+    }
+    
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        return redirect('/' . config('chatter.routes.home'))->with([
+            'chatter_alert_type' => 'danger',
+            'chatter_alert'      => trans('chatter::alert.danger.reason.destroy_post'),
+        ]);
+    }
+    
+}

--- a/src/Requests/ChatterDeletePostRequest.php
+++ b/src/Requests/ChatterDeletePostRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DevDojo\Chatter\Requests;
+
+use DevDojo\Chatter\Exceptions\ChatterUserIsNotAllowedToDeletePostException;
+use DevDojo\Chatter\Models\Models;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ChatterDeletePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $parameters = $this->route()->parameters;
+
+        $post = Models::post()->with('discussion')->findOrFail($parameters['post']);
+
+        return $this->user()->id === (int) $post->user_id;
+    }
+    
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     *
+     * @throws ChatterUserIsNotAllowedToDeletePostException
+     */
+    protected function failedAuthorization()
+    {
+        throw new ChatterUserIsNotAllowedToDeletePostException();
+    }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
I extracted the post delete authorization logic to a FormRequest subclass.
In case that you need, it allows you to write your own authorization logic in a custom FormRequest without you have to modify ChatterPostController class.